### PR TITLE
add siteone-crawler (fast Swoole-based website crawler, analyzer and exporter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ NOTE: Projects labelled with emoji :globe_with_meridians: have their documentati
 - [Shlink Event Dispatcher](https://github.com/shlinkio/shlink-event-dispatcher) - Event dispatching using PSR-14, with async event listener that are executed in swoole task system.
 - [xlswriter](https://github.com/viest/php-ext-xlswriter) - A coroutine-friendly PHP Extension to create and read XLSX files.
 - [swoole-utils](https://github.com/apinstein/swoole-utils) - A collection of utilities for building concurrent applications with Swoole. #WIP
+- [siteone-crawler](https://github.com/janreges/siteone-crawler) - A fast Swoole-based cross-platform website crawler, cloner and analyzer for SEO, security, accessibility, and performance optimization - ideal for developers, DevOps and QA engineers. Supports Windows, macOS, and Linux. Also available as [desktop application](https://github.com/janreges/siteone-crawler-gui) based on Svelte + Electron.
 
 # Resources
 


### PR DESCRIPTION
I have created an in-depth open-source website analyzer and exporter, which is a nice and useful use-case for Swoole. 

This PR adds this tool (SiteOne Crawler) to README.md.

In the README.md I refer to the GitHub repository, but here is also the homepage of this tool, where there is detailed documentation - https://crawler.siteone.io/